### PR TITLE
Add AEO improvements: JSON-LD, FAQ, format reference

### DIFF
--- a/app/formats/page.tsx
+++ b/app/formats/page.tsx
@@ -1,0 +1,200 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Discord Timestamp Format Reference — All 6 Format Codes",
+  description:
+    "Complete reference for Discord's six timestamp format codes (:f, :F, :d, :D, :t, :R). See what each renders, when to use it, and copy-paste examples.",
+  alternates: { canonical: "/formats" },
+  openGraph: {
+    title: "Discord Timestamp Format Reference",
+    description:
+      "Complete reference for Discord's six timestamp format codes with rendered examples.",
+    url: "https://timestamps.app/formats",
+    siteName: "timestamps.app",
+    type: "article",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Discord Timestamp Format Reference",
+    description:
+      "Complete reference for Discord's six timestamp format codes with rendered examples.",
+  },
+};
+
+const articleSchema = {
+  "@context": "https://schema.org",
+  "@type": "Article",
+  headline: "Discord Timestamp Format Reference",
+  description:
+    "Complete reference for Discord's six timestamp format codes (:f, :F, :d, :D, :t, :R) with rendered examples and guidance on when to use each.",
+  url: "https://timestamps.app/formats",
+  author: {
+    "@type": "Person",
+    name: "Niklas Peterson",
+    url: "https://niklaspeterson.com",
+  },
+  publisher: {
+    "@type": "Organization",
+    name: "timestamps.app",
+    url: "https://timestamps.app",
+  },
+  datePublished: "2026-05-05",
+  dateModified: new Date().toISOString().slice(0, 10),
+  mainEntityOfPage: {
+    "@type": "WebPage",
+    "@id": "https://timestamps.app/formats",
+  },
+};
+
+const FORMAT_CODES = [
+  {
+    code: ":f",
+    name: "Short date and time",
+    example: "December 25, 2025 3:00 PM",
+    when: "The default for most messages. Communicates a specific moment with both date and time.",
+  },
+  {
+    code: ":F",
+    name: "Long date and time",
+    example: "Thursday, December 25, 2025 3:00 PM",
+    when: "Use when the day of the week matters — meetings, events, deadlines.",
+  },
+  {
+    code: ":d",
+    name: "Short date",
+    example: "12/25/2025",
+    when: "Compact, no time. Good for date-only references in tables or lists.",
+  },
+  {
+    code: ":D",
+    name: "Long date",
+    example: "December 25, 2025",
+    when: "Spelled-out date, no time. Less ambiguous than :d for international audiences.",
+  },
+  {
+    code: ":t",
+    name: "Short time",
+    example: "3:00 PM",
+    when: "Time only — useful when the date is already known from context.",
+  },
+  {
+    code: ":R",
+    name: "Relative time",
+    example: '"in 3 hours" / "2 days ago"',
+    when: "Counts up or down from the current moment. Updates as time passes — perfect for countdowns.",
+  },
+];
+
+export default function FormatsPage() {
+  return (
+    <main className="w-full max-w-3xl px-4 py-12 md:py-20 flex flex-col gap-10">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+
+      <Link
+        href="/"
+        className="text-sm contentSecondary hover:contentPrimary w-fit focusLinkInline"
+      >
+        ← timestamps.app
+      </Link>
+
+      <article className="flex flex-col gap-10">
+        <header className="flex flex-col gap-4">
+          <h1 className="text-4xl md:text-5xl font-semibold">
+            Discord timestamp format reference
+          </h1>
+          <p className="text-lg contentSecondary">
+            Discord supports six timestamp format codes. Each one tells Discord how to render
+            a UNIX timestamp in the viewer&apos;s local timezone — so a single message reads
+            correctly for everyone, no matter where they are.
+          </p>
+        </header>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-2xl md:text-3xl font-semibold">How a Discord timestamp works</h2>
+          <p className="contentSecondary">
+            A Discord timestamp is a small inline tag of the form{" "}
+            <code>&lt;t:UNIX_SECONDS:CODE&gt;</code>. Discord parses it client-side and shows
+            the corresponding date or time in each viewer&apos;s timezone. The{" "}
+            <code>UNIX_SECONDS</code> is a{" "}
+            <Link href="/unix-timestamp" className="underline">UNIX timestamp</Link> — the
+            number of seconds since 00:00:00 UTC on 1 January 1970. The trailing letter is the
+            format code.
+          </p>
+          <p className="contentSecondary">
+            For example, <code>&lt;t:1735138800:F&gt;</code> renders as{" "}
+            <em>Thursday, December 25, 2025 3:00 PM</em> for a viewer in New York and{" "}
+            <em>Friday, December 26, 2025 8:00 AM</em> for a viewer in Tokyo — both pointing
+            to the same instant.
+          </p>
+          <p className="contentSecondary">
+            The fastest way to get a correctly formatted tag is to{" "}
+            <Link href="/" className="underline">use the timestamp generator</Link>: pick a
+            date and time, copy the format you want, and paste it into Discord.
+          </p>
+        </section>
+
+        <section className="flex flex-col gap-6">
+          <h2 className="text-2xl md:text-3xl font-semibold">The six format codes</h2>
+          {FORMAT_CODES.map(({ code, name, example, when }) => (
+            <div key={code} className="flex flex-col gap-1">
+              <h3 className="font-semibold">
+                <code>{code}</code> — {name}
+              </h3>
+              <p className="contentSecondary">
+                <strong>Renders as:</strong> {example}
+              </p>
+              <p className="contentSecondary">
+                <strong>When to use:</strong> {when}
+              </p>
+            </div>
+          ))}
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-2xl md:text-3xl font-semibold">Choosing the right format</h2>
+          <p className="contentSecondary">
+            For event announcements, <code>:F</code> reads cleanly because the day of the week
+            anchors the date. For countdowns and reminders, <code>:R</code> stays useful as
+            time passes — &quot;in 3 days&quot; becomes &quot;in 2 hours&quot; without you
+            editing the message. For brief inline references where the date is already
+            implied, <code>:t</code> keeps the line short.
+          </p>
+          <p className="contentSecondary">
+            A common pattern is to combine two: an absolute time alongside a relative one,
+            like <code>&lt;t:...:F&gt;</code> (<code>&lt;t:...:R&gt;</code>). The reader sees
+            both the wall-clock time and how soon it is.
+          </p>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-2xl md:text-3xl font-semibold">Where Discord renders timestamps</h2>
+          <p className="contentSecondary">
+            Discord renders these tags in messages, embeds, channel descriptions, and forum
+            posts. Bots can include them in webhook payloads. The same format works in
+            third-party platforms that follow Discord&apos;s timestamp convention.
+          </p>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-2xl md:text-3xl font-semibold">Related</h2>
+          <ul className="flex flex-col gap-2">
+            <li>
+              <Link href="/" className="underline">
+                → Generate a Discord timestamp
+              </Link>
+            </li>
+            <li>
+              <Link href="/unix-timestamp" className="underline">
+                → What is a UNIX timestamp?
+              </Link>
+            </li>
+          </ul>
+        </section>
+      </article>
+    </main>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -60,11 +60,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${inter.className} antialiased p-sa contentPrimary flex flex-col min-h-screen justify-start items-start bg-white dark:bg-black md:justify-center md:items-center`}>
-        <div
-          aria-hidden="true"
-          className="fixed inset-0 -z-10 pointer-events-none bg-no-repeat bg-center bg-cover md:bg-auto bg-[url(../public/bg.png)]"
-        />
+        className={`${inter.className} antialiased p-sa contentPrimary flex flex-col min-h-screen justify-start items-start bg-white dark:bg-black bg-no-repeat bg-[url(../public/bg.png)] bg-center bg-cover md:bg-auto  md:justify-center md:items-center`}>
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(webApplicationSchema) }}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -48,6 +48,8 @@ const webApplicationSchema = {
     name: "Niklas Peterson",
     url: "https://niklaspeterson.com",
   },
+  datePublished: "2021-10-17",
+  dateModified: new Date().toISOString().slice(0, 10),
 };
 
 const faqSchema = {
@@ -59,7 +61,7 @@ const faqSchema = {
       name: "How do I generate a Discord timestamp?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "Pick a date and time on timestamps.app, then copy any of the six Discord timestamp formats (e.g. <t:1700000000:F>) and paste it into a Discord message. Discord will render it in each viewer's local timezone.",
+        text: "Pick a date and time on timestamps.app, then copy any of the six Discord timestamp formats (e.g. <t:1700000000:F>) and paste it into a Discord message. Discord will render it in each viewer's local timezone. See the full list of Discord timestamp format codes for what each one renders.",
       },
     },
     {
@@ -67,7 +69,7 @@ const faqSchema = {
       name: "What is a UNIX timestamp?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "A UNIX timestamp is the number of seconds since 00:00:00 UTC on 1 January 1970. It is the format Discord and many other platforms use to represent a moment in time independently of timezone.",
+        text: "A UNIX timestamp is the number of seconds since 00:00:00 UTC on 1 January 1970. It is the format Discord and many other platforms use to represent a moment in time independently of timezone. Discord wraps the timestamp in a format code tag to control how it's displayed.",
       },
     },
     {
@@ -75,7 +77,7 @@ const faqSchema = {
       name: "What do the Discord timestamp format codes mean?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "<p>Discord supports six timestamp format codes. Append the code to a UNIX timestamp inside &lt;t:...&gt; to control how Discord renders the date and time in each viewer's local timezone.</p><ul><li><strong>:f</strong> — Short date and time (e.g. December 25, 2025 3:00 PM)</li><li><strong>:F</strong> — Long date and time (e.g. Thursday, December 25, 2025 3:00 PM)</li><li><strong>:d</strong> — Short date (e.g. 12/25/2025)</li><li><strong>:D</strong> — Long date (e.g. December 25, 2025)</li><li><strong>:t</strong> — Short time (e.g. 3:00 PM)</li><li><strong>:R</strong> — Relative time (e.g. \"in 3 hours\")</li></ul>",
+        text: "<p>Discord supports six timestamp format codes. Append the code to a UNIX timestamp inside &lt;t:...&gt; to control how Discord renders the date and time in each viewer's local timezone. For a quick start, see how to generate a Discord timestamp.</p><ul><li><strong>:f</strong> — Short date and time (e.g. December 25, 2025 3:00 PM)</li><li><strong>:F</strong> — Long date and time (e.g. Thursday, December 25, 2025 3:00 PM)</li><li><strong>:d</strong> — Short date (e.g. 12/25/2025)</li><li><strong>:D</strong> — Long date (e.g. December 25, 2025)</li><li><strong>:t</strong> — Short time (e.g. 3:00 PM)</li><li><strong>:R</strong> — Relative time (e.g. \"in 3 hours\")</li></ul>",
       },
     },
     {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -60,7 +60,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${inter.className} antialiased p-sa contentPrimary flex flex-col min-h-screen justify-start items-start bg-white dark:bg-black bg-no-repeat bg-[url(../public/bg.png)] bg-center bg-cover md:bg-auto  md:justify-center md:items-center`}>
+        className={`${inter.className} antialiased p-sa contentPrimary flex flex-col min-h-screen justify-start items-start bg-white dark:bg-black md:justify-center md:items-center`}>
+        <div
+          aria-hidden="true"
+          className="fixed inset-0 -z-10 pointer-events-none bg-no-repeat bg-center bg-cover md:bg-auto bg-[url(../public/bg.png)]"
+        />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(webApplicationSchema) }}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -52,45 +52,6 @@ const webApplicationSchema = {
   dateModified: new Date().toISOString().slice(0, 10),
 };
 
-const faqSchema = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: [
-    {
-      "@type": "Question",
-      name: "How do I generate a Discord timestamp?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Pick a date and time on timestamps.app, then copy any of the six Discord timestamp formats (e.g. <t:1700000000:F>) and paste it into a Discord message. Discord will render it in each viewer's local timezone. See the full list of Discord timestamp format codes for what each one renders.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "What is a UNIX timestamp?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "A UNIX timestamp is the number of seconds since 00:00:00 UTC on 1 January 1970. It is the format Discord and many other platforms use to represent a moment in time independently of timezone. Discord wraps the timestamp in a format code tag to control how it's displayed.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "What do the Discord timestamp format codes mean?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "<p>Discord supports six timestamp format codes. Append the code to a UNIX timestamp inside &lt;t:...&gt; to control how Discord renders the date and time in each viewer's local timezone. For a quick start, see how to generate a Discord timestamp.</p><ul><li><strong>:f</strong> — Short date and time (e.g. December 25, 2025 3:00 PM)</li><li><strong>:F</strong> — Long date and time (e.g. Thursday, December 25, 2025 3:00 PM)</li><li><strong>:d</strong> — Short date (e.g. 12/25/2025)</li><li><strong>:D</strong> — Long date (e.g. December 25, 2025)</li><li><strong>:t</strong> — Short time (e.g. 3:00 PM)</li><li><strong>:R</strong> — Relative time (e.g. \"in 3 hours\")</li></ul>",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Is timestamps.app free?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Yes. timestamps.app is free, requires no sign-up, and runs entirely in your browser.",
-      },
-    },
-  ],
-};
-
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -103,10 +64,6 @@ export default function RootLayout({
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(webApplicationSchema) }}
-        />
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
         />
         <AnalyticsTracker />
         {children}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -75,7 +75,7 @@ const faqSchema = {
       name: "What do the Discord timestamp format codes mean?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "f = short date and time, F = long date and time, d = short date, D = long date, t = short time, R = relative time (e.g. 'in 3 hours').",
+        text: "<p>Discord supports six timestamp format codes. Append the code to a UNIX timestamp inside &lt;t:...&gt; to control how Discord renders the date and time in each viewer's local timezone.</p><ul><li><strong>:f</strong> — Short date and time (e.g. December 25, 2025 3:00 PM)</li><li><strong>:F</strong> — Long date and time (e.g. Thursday, December 25, 2025 3:00 PM)</li><li><strong>:d</strong> — Short date (e.g. 12/25/2025)</li><li><strong>:D</strong> — Long date (e.g. December 25, 2025)</li><li><strong>:t</strong> — Short time (e.g. 3:00 PM)</li><li><strong>:R</strong> — Relative time (e.g. \"in 3 hours\")</li></ul>",
       },
     },
     {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,8 +7,24 @@ import AnalyticsTracker from './components/AnalyticsTracker';
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: "Timestamps - Generate UNIX timestamps",
-  description: "Generate and format UNIX timestamps for Discord and other platforms easily with timestamps.app",
+  metadataBase: new URL("https://timestamps.app"),
+  title: "Discord Timestamp Generator — UNIX timestamps for Discord",
+  description:
+    "Free online tool to generate Discord timestamps and UNIX timestamps. Pick any date and time, then copy the <t:...> format Discord and other platforms need. No sign-up required.",
+  alternates: { canonical: "/" },
+  openGraph: {
+    title: "Discord Timestamp Generator — UNIX timestamps for Discord",
+    description:
+      "Generate Discord-ready <t:...> timestamps and UNIX timestamps from any date and time. Free, no sign-up.",
+    url: "https://timestamps.app",
+    siteName: "timestamps.app",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Discord Timestamp Generator",
+    description: "Generate Discord-ready <t:...> timestamps from any date and time.",
+  },
 };
 
 export const viewport: Viewport = {
@@ -16,6 +32,62 @@ export const viewport: Viewport = {
   initialScale: 1,
   viewportFit: "cover",
 }
+
+const webApplicationSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  name: "timestamps.app",
+  url: "https://timestamps.app",
+  applicationCategory: "UtilitiesApplication",
+  operatingSystem: "Any",
+  description:
+    "Free tool to generate Discord timestamps and UNIX timestamps from any date and time.",
+  offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+  author: {
+    "@type": "Person",
+    name: "Niklas Peterson",
+    url: "https://niklaspeterson.com",
+  },
+};
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "How do I generate a Discord timestamp?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Pick a date and time on timestamps.app, then copy any of the six Discord timestamp formats (e.g. <t:1700000000:F>) and paste it into a Discord message. Discord will render it in each viewer's local timezone.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "What is a UNIX timestamp?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "A UNIX timestamp is the number of seconds since 00:00:00 UTC on 1 January 1970. It is the format Discord and many other platforms use to represent a moment in time independently of timezone.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "What do the Discord timestamp format codes mean?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "f = short date and time, F = long date and time, d = short date, D = long date, t = short time, R = relative time (e.g. 'in 3 hours').",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Is timestamps.app free?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes. timestamps.app is free, requires no sign-up, and runs entirely in your browser.",
+      },
+    },
+  ],
+};
 
 export default function RootLayout({
   children,
@@ -26,6 +98,14 @@ export default function RootLayout({
     <html lang="en">
       <body
         className={`${inter.className} antialiased p-sa contentPrimary flex flex-col min-h-screen justify-start items-start bg-white dark:bg-black bg-no-repeat bg-[url(../public/bg.png)] bg-center bg-cover md:bg-auto  md:justify-center md:items-center`}>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(webApplicationSchema) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+        />
         <AnalyticsTracker />
         {children}
         <Toaster />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,47 @@ import ResultList from "./components/ResultList";
 import DatePicker from './components/DatePicker';
 import moment, { Moment } from 'moment';
 import Image from 'next/image';
+import Link from 'next/link';
 import ServerCount from './components/ServerCount';
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "How do I generate a Discord timestamp?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Pick a date and time on timestamps.app, then copy any of the six Discord timestamp formats (e.g. <t:1700000000:F>) and paste it into a Discord message. Discord will render it in each viewer's local timezone. See the full Discord timestamp format reference for what each code renders.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "What is a UNIX timestamp?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "A UNIX timestamp is the number of seconds since 00:00:00 UTC on 1 January 1970. It is the format Discord and many other platforms use to represent a moment in time independently of timezone. The dedicated UNIX timestamp explainer covers the epoch, conversions, and how Discord uses it.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "What do the Discord timestamp format codes mean?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "<p>Discord supports six timestamp format codes. Append the code to a UNIX timestamp inside &lt;t:...&gt; to control how Discord renders the date and time in each viewer's local timezone.</p><ul><li><strong>:f</strong> — Short date and time (e.g. December 25, 2025 3:00 PM)</li><li><strong>:F</strong> — Long date and time (e.g. Thursday, December 25, 2025 3:00 PM)</li><li><strong>:d</strong> — Short date (e.g. 12/25/2025)</li><li><strong>:D</strong> — Long date (e.g. December 25, 2025)</li><li><strong>:t</strong> — Short time (e.g. 3:00 PM)</li><li><strong>:R</strong> — Relative time (e.g. \"in 3 hours\")</li></ul><p>The format reference page has examples and guidance on when to pick each code.</p>",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Is timestamps.app free?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes. timestamps.app is free, requires no sign-up, and runs entirely in your browser.",
+      },
+    },
+  ],
+};
 
 export default function Home() {
   const [dateTime, setDateTime] = useState<Moment>(moment());
@@ -17,6 +57,10 @@ export default function Home() {
 
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
       <div className="flex w-full pr-sa md:top-0 md:absolute">
         <div className="flex w-full mx-4 mt-4 gap-2 justify-end flex-col md:flex-row">
           <AppCard
@@ -143,14 +187,14 @@ export default function Home() {
         <div className="flex flex-col gap-2">
           <h3 id="faq-how" className="font-semibold">How do I generate a Discord timestamp?</h3>
           <p className="contentSecondary">
-            Pick a date and time on timestamps.app, then copy any of the six Discord timestamp formats (e.g. <code>&lt;t:1700000000:F&gt;</code>) and paste it into a Discord message. Discord will render it in each viewer&apos;s local timezone. See the <a href="#faq-format-codes" className="underline">full list of Discord timestamp format codes</a> for what each one renders.
+            Pick a date and time on timestamps.app, then copy any of the six Discord timestamp formats (e.g. <code>&lt;t:1700000000:F&gt;</code>) and paste it into a Discord message. Discord will render it in each viewer&apos;s local timezone. See the <Link href="/formats" className="underline">full Discord timestamp format reference</Link> for what each code renders.
           </p>
         </div>
 
         <div className="flex flex-col gap-2">
           <h3 id="faq-format-codes" className="font-semibold">What do the Discord timestamp format codes mean?</h3>
           <p className="contentSecondary">
-            Discord supports six timestamp format codes. Append the code to a UNIX timestamp inside <code>&lt;t:...&gt;</code> to control how Discord renders the date and time in each viewer&apos;s local timezone. For a quick start, see <a href="#faq-how" className="underline">how to generate a Discord timestamp</a>.
+            Discord supports six timestamp format codes. Append the code to a UNIX timestamp inside <code>&lt;t:...&gt;</code> to control how Discord renders the date and time in each viewer&apos;s local timezone.
           </p>
           <ul className="flex flex-col gap-2 contentSecondary">
             <li><strong><code>:f</code></strong> — Short date and time (e.g. December 25, 2025 3:00 PM)</li>
@@ -160,12 +204,15 @@ export default function Home() {
             <li><strong><code>:t</code></strong> — Short time (e.g. 3:00 PM)</li>
             <li><strong><code>:R</code></strong> — Relative time (e.g. &quot;in 3 hours&quot;)</li>
           </ul>
+          <p className="contentSecondary">
+            The <Link href="/formats" className="underline">format reference page</Link> has examples and guidance on when to pick each code.
+          </p>
         </div>
 
         <div className="flex flex-col gap-2">
           <h3 id="faq-unix" className="font-semibold">What is a UNIX timestamp?</h3>
           <p className="contentSecondary">
-            A UNIX timestamp is the number of seconds since 00:00:00 UTC on 1 January 1970. It is the format Discord and many other platforms use to represent a moment in time independently of timezone. Discord wraps the timestamp in <a href="#faq-format-codes" className="underline">a format code tag</a> to control how it&apos;s displayed.
+            A UNIX timestamp is the number of seconds since 00:00:00 UTC on 1 January 1970. It is the format Discord and many other platforms use to represent a moment in time independently of timezone. The dedicated <Link href="/unix-timestamp" className="underline">UNIX timestamp explainer</Link> covers the epoch, conversions, and how Discord uses it.
           </p>
         </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -133,26 +133,6 @@ export default function Home() {
       </main>
 
       <section
-        aria-labelledby="format-reference"
-        className="w-full max-w-3xl px-4 mb-12 flex flex-col gap-4"
-      >
-        <h2 id="format-reference" className="text-2xl font-semibold md:text-3xl">
-          Discord timestamp format reference
-        </h2>
-        <p className="contentSecondary">
-          Discord supports six timestamp format codes. Append the code to a UNIX timestamp inside <code>&lt;t:...&gt;</code> to control how Discord renders the date and time in each viewer&apos;s local timezone.
-        </p>
-        <ul className="flex flex-col gap-2">
-          <li><strong><code>:f</code></strong> — Short date and time (e.g. December 25, 2025 3:00 PM)</li>
-          <li><strong><code>:F</code></strong> — Long date and time (e.g. Thursday, December 25, 2025 3:00 PM)</li>
-          <li><strong><code>:d</code></strong> — Short date (e.g. 12/25/2025)</li>
-          <li><strong><code>:D</code></strong> — Long date (e.g. December 25, 2025)</li>
-          <li><strong><code>:t</code></strong> — Short time (e.g. 3:00 PM)</li>
-          <li><strong><code>:R</code></strong> — Relative time (e.g. &quot;in 3 hours&quot;)</li>
-        </ul>
-      </section>
-
-      <section
         aria-labelledby="faq"
         className="w-full max-w-3xl px-4 mb-16 flex flex-col gap-6"
       >
@@ -168,16 +148,24 @@ export default function Home() {
         </div>
 
         <div className="flex flex-col gap-2">
-          <h3 className="font-semibold">What is a UNIX timestamp?</h3>
+          <h3 className="font-semibold">What do the Discord timestamp format codes mean?</h3>
           <p className="contentSecondary">
-            A UNIX timestamp is the number of seconds since 00:00:00 UTC on 1 January 1970. It is the format Discord and many other platforms use to represent a moment in time independently of timezone.
+            Discord supports six timestamp format codes. Append the code to a UNIX timestamp inside <code>&lt;t:...&gt;</code> to control how Discord renders the date and time in each viewer&apos;s local timezone.
           </p>
+          <ul className="flex flex-col gap-2 contentSecondary">
+            <li><strong><code>:f</code></strong> — Short date and time (e.g. December 25, 2025 3:00 PM)</li>
+            <li><strong><code>:F</code></strong> — Long date and time (e.g. Thursday, December 25, 2025 3:00 PM)</li>
+            <li><strong><code>:d</code></strong> — Short date (e.g. 12/25/2025)</li>
+            <li><strong><code>:D</code></strong> — Long date (e.g. December 25, 2025)</li>
+            <li><strong><code>:t</code></strong> — Short time (e.g. 3:00 PM)</li>
+            <li><strong><code>:R</code></strong> — Relative time (e.g. &quot;in 3 hours&quot;)</li>
+          </ul>
         </div>
 
         <div className="flex flex-col gap-2">
-          <h3 className="font-semibold">What do the Discord timestamp format codes mean?</h3>
+          <h3 className="font-semibold">What is a UNIX timestamp?</h3>
           <p className="contentSecondary">
-            f = short date and time, F = long date and time, d = short date, D = long date, t = short time, R = relative time (e.g. &quot;in 3 hours&quot;).
+            A UNIX timestamp is the number of seconds since 00:00:00 UTC on 1 January 1970. It is the format Discord and many other platforms use to represent a moment in time independently of timezone.
           </p>
         </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,6 +39,14 @@ const faqSchema = {
     },
     {
       "@type": "Question",
+      name: "Is there a Discord bot?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes. timestamps.app has a companion Discord bot that brings the timestamp generator directly into Discord, so you can grab a formatted timestamp without leaving the server. Add it from the home page or via https://discord.com/oauth2/authorize?client_id=1031598414280015915.",
+      },
+    },
+    {
+      "@type": "Question",
       name: "Is timestamps.app free?",
       acceptedAnswer: {
         "@type": "Answer",
@@ -47,6 +55,43 @@ const faqSchema = {
     },
   ],
 };
+
+function FaqItem({
+  id,
+  question,
+  children,
+}: {
+  id: string;
+  question: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <details
+      id={id}
+      className="group rounded-xl border border-zinc-200 dark:border-zinc-700 bg-white/40 dark:bg-zinc-900/40 backdrop-blur-sm overflow-hidden"
+    >
+      <summary className="flex items-center justify-between gap-3 px-4 py-3 cursor-pointer list-none [&::-webkit-details-marker]:hidden hover:bg-zinc-50/60 dark:hover:bg-zinc-800/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#5865F2]/35 transition-colors">
+        <h3 className="font-semibold">{question}</h3>
+        <svg
+          className="size-5 contentSecondary transition-transform duration-200 group-open:rotate-180 shrink-0"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fillRule="evenodd"
+            d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </summary>
+      <div className="px-4 pb-4 contentSecondary flex flex-col gap-2">
+        {children}
+      </div>
+    </details>
+  );
+}
 
 export default function Home() {
   const [dateTime, setDateTime] = useState<Moment>(moment());
@@ -184,43 +229,56 @@ export default function Home() {
           Frequently asked questions
         </h2>
 
-        <div className="flex flex-col gap-2">
-          <h3 id="faq-how" className="font-semibold">How do I generate a Discord timestamp?</h3>
-          <p className="contentSecondary">
-            Pick a date and time on timestamps.app, then copy any of the six Discord timestamp formats (e.g. <code>&lt;t:1700000000:F&gt;</code>) and paste it into a Discord message. Discord will render it in each viewer&apos;s local timezone. See the <Link href="/formats" className="underline">full Discord timestamp format reference</Link> for what each code renders.
-          </p>
-        </div>
+        <div className="flex flex-col gap-3">
+          <FaqItem id="faq-how" question="How do I generate a Discord timestamp?">
+            <p>
+              Pick a date and time on timestamps.app, then copy any of the six Discord timestamp formats (e.g. <code>&lt;t:1700000000:F&gt;</code>) and paste it into a Discord message. Discord will render it in each viewer&apos;s local timezone. See the <Link href="/formats" className="underline">full Discord timestamp format reference</Link> for what each code renders.
+            </p>
+          </FaqItem>
 
-        <div className="flex flex-col gap-2">
-          <h3 id="faq-format-codes" className="font-semibold">What do the Discord timestamp format codes mean?</h3>
-          <p className="contentSecondary">
-            Discord supports six timestamp format codes. Append the code to a UNIX timestamp inside <code>&lt;t:...&gt;</code> to control how Discord renders the date and time in each viewer&apos;s local timezone.
-          </p>
-          <ul className="flex flex-col gap-2 contentSecondary">
-            <li><strong><code>:f</code></strong> — Short date and time (e.g. December 25, 2025 3:00 PM)</li>
-            <li><strong><code>:F</code></strong> — Long date and time (e.g. Thursday, December 25, 2025 3:00 PM)</li>
-            <li><strong><code>:d</code></strong> — Short date (e.g. 12/25/2025)</li>
-            <li><strong><code>:D</code></strong> — Long date (e.g. December 25, 2025)</li>
-            <li><strong><code>:t</code></strong> — Short time (e.g. 3:00 PM)</li>
-            <li><strong><code>:R</code></strong> — Relative time (e.g. &quot;in 3 hours&quot;)</li>
-          </ul>
-          <p className="contentSecondary">
-            The <Link href="/formats" className="underline">format reference page</Link> has examples and guidance on when to pick each code.
-          </p>
-        </div>
+          <FaqItem id="faq-format-codes" question="What do the Discord timestamp format codes mean?">
+            <p>
+              Discord supports six timestamp format codes. Append the code to a UNIX timestamp inside <code>&lt;t:...&gt;</code> to control how Discord renders the date and time in each viewer&apos;s local timezone.
+            </p>
+            <ul className="flex flex-col gap-2">
+              <li><strong><code>:f</code></strong> — Short date and time (e.g. December 25, 2025 3:00 PM)</li>
+              <li><strong><code>:F</code></strong> — Long date and time (e.g. Thursday, December 25, 2025 3:00 PM)</li>
+              <li><strong><code>:d</code></strong> — Short date (e.g. 12/25/2025)</li>
+              <li><strong><code>:D</code></strong> — Long date (e.g. December 25, 2025)</li>
+              <li><strong><code>:t</code></strong> — Short time (e.g. 3:00 PM)</li>
+              <li><strong><code>:R</code></strong> — Relative time (e.g. &quot;in 3 hours&quot;)</li>
+            </ul>
+            <p>
+              The <Link href="/formats" className="underline">format reference page</Link> has examples and guidance on when to pick each code.
+            </p>
+          </FaqItem>
 
-        <div className="flex flex-col gap-2">
-          <h3 id="faq-unix" className="font-semibold">What is a UNIX timestamp?</h3>
-          <p className="contentSecondary">
-            A UNIX timestamp is the number of seconds since 00:00:00 UTC on 1 January 1970. It is the format Discord and many other platforms use to represent a moment in time independently of timezone. The dedicated <Link href="/unix-timestamp" className="underline">UNIX timestamp explainer</Link> covers the epoch, conversions, and how Discord uses it.
-          </p>
-        </div>
+          <FaqItem id="faq-unix" question="What is a UNIX timestamp?">
+            <p>
+              A UNIX timestamp is the number of seconds since 00:00:00 UTC on 1 January 1970. It is the format Discord and many other platforms use to represent a moment in time independently of timezone. The dedicated <Link href="/unix-timestamp" className="underline">UNIX timestamp explainer</Link> covers the epoch, conversions, and how Discord uses it.
+            </p>
+          </FaqItem>
 
-        <div className="flex flex-col gap-2">
-          <h3 id="faq-free" className="font-semibold">Is timestamps.app free?</h3>
-          <p className="contentSecondary">
-            Yes. timestamps.app is free, requires no sign-up, and runs entirely in your browser.
-          </p>
+          <FaqItem id="faq-bot" question="Is there a Discord bot?">
+            <p>
+              Yes. timestamps.app has a companion Discord bot that brings the timestamp generator directly into Discord, so you can grab a formatted timestamp without leaving the server.{" "}
+              <a
+                href="https://discord.com/oauth2/authorize?client_id=1031598414280015915"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                Add it to your server
+              </a>
+              .
+            </p>
+          </FaqItem>
+
+          <FaqItem id="faq-free" question="Is timestamps.app free?">
+            <p>
+              Yes. timestamps.app is free, requires no sign-up, and runs entirely in your browser.
+            </p>
+          </FaqItem>
         </div>
       </section>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,92 +6,7 @@ import ResultList from "./components/ResultList";
 import DatePicker from './components/DatePicker';
 import moment, { Moment } from 'moment';
 import Image from 'next/image';
-import Link from 'next/link';
 import ServerCount from './components/ServerCount';
-
-const faqSchema = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: [
-    {
-      "@type": "Question",
-      name: "How do I generate a Discord timestamp?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Pick a date and time on timestamps.app, then copy any of the six Discord timestamp formats (e.g. <t:1700000000:F>) and paste it into a Discord message. Discord will render it in each viewer's local timezone. See the full Discord timestamp format reference for what each code renders.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "What is a UNIX timestamp?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "A UNIX timestamp is the number of seconds since 00:00:00 UTC on 1 January 1970. It is the format Discord and many other platforms use to represent a moment in time independently of timezone. The dedicated UNIX timestamp explainer covers the epoch, conversions, and how Discord uses it.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "What do the Discord timestamp format codes mean?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "<p>Discord supports six timestamp format codes. Append the code to a UNIX timestamp inside &lt;t:...&gt; to control how Discord renders the date and time in each viewer's local timezone.</p><ul><li><strong>:f</strong> — Short date and time (e.g. December 25, 2025 3:00 PM)</li><li><strong>:F</strong> — Long date and time (e.g. Thursday, December 25, 2025 3:00 PM)</li><li><strong>:d</strong> — Short date (e.g. 12/25/2025)</li><li><strong>:D</strong> — Long date (e.g. December 25, 2025)</li><li><strong>:t</strong> — Short time (e.g. 3:00 PM)</li><li><strong>:R</strong> — Relative time (e.g. \"in 3 hours\")</li></ul><p>The format reference page has examples and guidance on when to pick each code.</p>",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Is there a Discord bot?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Yes. timestamps.app has a companion Discord bot that brings the timestamp generator directly into Discord, so you can grab a formatted timestamp without leaving the server. Add it from the home page or via https://discord.com/oauth2/authorize?client_id=1031598414280015915.",
-      },
-    },
-    {
-      "@type": "Question",
-      name: "Is timestamps.app free?",
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: "Yes. timestamps.app is free, requires no sign-up, and runs entirely in your browser.",
-      },
-    },
-  ],
-};
-
-function FaqItem({
-  id,
-  question,
-  children,
-}: {
-  id: string;
-  question: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <details
-      id={id}
-      className="group rounded-xl border border-zinc-200 dark:border-zinc-700 bg-white/40 dark:bg-zinc-900/40 backdrop-blur-sm overflow-hidden"
-    >
-      <summary className="flex items-center justify-between gap-3 px-4 py-3 cursor-pointer list-none [&::-webkit-details-marker]:hidden hover:bg-zinc-50/60 dark:hover:bg-zinc-800/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#5865F2]/35 transition-colors">
-        <h3 className="font-semibold">{question}</h3>
-        <svg
-          className="size-5 contentSecondary transition-transform duration-200 group-open:rotate-180 shrink-0"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-          aria-hidden="true"
-        >
-          <path
-            fillRule="evenodd"
-            d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z"
-            clipRule="evenodd"
-          />
-        </svg>
-      </summary>
-      <div className="px-4 pb-4 contentSecondary flex flex-col gap-2">
-        {children}
-      </div>
-    </details>
-  );
-}
 
 export default function Home() {
   const [dateTime, setDateTime] = useState<Moment>(moment());
@@ -102,10 +17,6 @@ export default function Home() {
 
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
-      />
       <div className="flex w-full pr-sa md:top-0 md:absolute">
         <div className="flex w-full mx-4 mt-4 gap-2 justify-end flex-col md:flex-row">
           <AppCard
@@ -220,67 +131,6 @@ export default function Home() {
         </div>
 
       </main>
-
-      <section
-        aria-labelledby="faq"
-        className="w-full max-w-3xl px-4 mb-16 flex flex-col gap-6"
-      >
-        <h2 id="faq" className="text-2xl font-semibold md:text-3xl">
-          Frequently asked questions
-        </h2>
-
-        <div className="flex flex-col gap-3">
-          <FaqItem id="faq-how" question="How do I generate a Discord timestamp?">
-            <p>
-              Pick a date and time on timestamps.app, then copy any of the six Discord timestamp formats (e.g. <code>&lt;t:1700000000:F&gt;</code>) and paste it into a Discord message. Discord will render it in each viewer&apos;s local timezone. See the <Link href="/formats" className="underline">full Discord timestamp format reference</Link> for what each code renders.
-            </p>
-          </FaqItem>
-
-          <FaqItem id="faq-format-codes" question="What do the Discord timestamp format codes mean?">
-            <p>
-              Discord supports six timestamp format codes. Append the code to a UNIX timestamp inside <code>&lt;t:...&gt;</code> to control how Discord renders the date and time in each viewer&apos;s local timezone.
-            </p>
-            <ul className="flex flex-col gap-2">
-              <li><strong><code>:f</code></strong> — Short date and time (e.g. December 25, 2025 3:00 PM)</li>
-              <li><strong><code>:F</code></strong> — Long date and time (e.g. Thursday, December 25, 2025 3:00 PM)</li>
-              <li><strong><code>:d</code></strong> — Short date (e.g. 12/25/2025)</li>
-              <li><strong><code>:D</code></strong> — Long date (e.g. December 25, 2025)</li>
-              <li><strong><code>:t</code></strong> — Short time (e.g. 3:00 PM)</li>
-              <li><strong><code>:R</code></strong> — Relative time (e.g. &quot;in 3 hours&quot;)</li>
-            </ul>
-            <p>
-              The <Link href="/formats" className="underline">format reference page</Link> has examples and guidance on when to pick each code.
-            </p>
-          </FaqItem>
-
-          <FaqItem id="faq-unix" question="What is a UNIX timestamp?">
-            <p>
-              A UNIX timestamp is the number of seconds since 00:00:00 UTC on 1 January 1970. It is the format Discord and many other platforms use to represent a moment in time independently of timezone. The dedicated <Link href="/unix-timestamp" className="underline">UNIX timestamp explainer</Link> covers the epoch, conversions, and how Discord uses it.
-            </p>
-          </FaqItem>
-
-          <FaqItem id="faq-bot" question="Is there a Discord bot?">
-            <p>
-              Yes. timestamps.app has a companion Discord bot that brings the timestamp generator directly into Discord, so you can grab a formatted timestamp without leaving the server.{" "}
-              <a
-                href="https://discord.com/oauth2/authorize?client_id=1031598414280015915"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline"
-              >
-                Add it to your server
-              </a>
-              .
-            </p>
-          </FaqItem>
-
-          <FaqItem id="faq-free" question="Is timestamps.app free?">
-            <p>
-              Yes. timestamps.app is free, requires no sign-up, and runs entirely in your browser.
-            </p>
-          </FaqItem>
-        </div>
-      </section>
 
       <footer className='flex flex-col w-full mb-4 items-center gap-2 md:hidden'>
         <div className="flex gap-1">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -132,6 +132,63 @@ export default function Home() {
 
       </main>
 
+      <section
+        aria-labelledby="format-reference"
+        className="w-full max-w-3xl px-4 mb-12 flex flex-col gap-4"
+      >
+        <h2 id="format-reference" className="text-2xl font-semibold md:text-3xl">
+          Discord timestamp format reference
+        </h2>
+        <p className="contentSecondary">
+          Discord supports six timestamp format codes. Append the code to a UNIX timestamp inside <code>&lt;t:...&gt;</code> to control how Discord renders the date and time in each viewer&apos;s local timezone.
+        </p>
+        <ul className="flex flex-col gap-2">
+          <li><strong><code>:f</code></strong> — Short date and time (e.g. December 25, 2025 3:00 PM)</li>
+          <li><strong><code>:F</code></strong> — Long date and time (e.g. Thursday, December 25, 2025 3:00 PM)</li>
+          <li><strong><code>:d</code></strong> — Short date (e.g. 12/25/2025)</li>
+          <li><strong><code>:D</code></strong> — Long date (e.g. December 25, 2025)</li>
+          <li><strong><code>:t</code></strong> — Short time (e.g. 3:00 PM)</li>
+          <li><strong><code>:R</code></strong> — Relative time (e.g. &quot;in 3 hours&quot;)</li>
+        </ul>
+      </section>
+
+      <section
+        aria-labelledby="faq"
+        className="w-full max-w-3xl px-4 mb-16 flex flex-col gap-6"
+      >
+        <h2 id="faq" className="text-2xl font-semibold md:text-3xl">
+          Frequently asked questions
+        </h2>
+
+        <div className="flex flex-col gap-2">
+          <h3 className="font-semibold">How do I generate a Discord timestamp?</h3>
+          <p className="contentSecondary">
+            Pick a date and time on timestamps.app, then copy any of the six Discord timestamp formats (e.g. <code>&lt;t:1700000000:F&gt;</code>) and paste it into a Discord message. Discord will render it in each viewer&apos;s local timezone.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <h3 className="font-semibold">What is a UNIX timestamp?</h3>
+          <p className="contentSecondary">
+            A UNIX timestamp is the number of seconds since 00:00:00 UTC on 1 January 1970. It is the format Discord and many other platforms use to represent a moment in time independently of timezone.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <h3 className="font-semibold">What do the Discord timestamp format codes mean?</h3>
+          <p className="contentSecondary">
+            f = short date and time, F = long date and time, d = short date, D = long date, t = short time, R = relative time (e.g. &quot;in 3 hours&quot;).
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <h3 className="font-semibold">Is timestamps.app free?</h3>
+          <p className="contentSecondary">
+            Yes. timestamps.app is free, requires no sign-up, and runs entirely in your browser.
+          </p>
+        </div>
+      </section>
+
       <footer className='flex flex-col w-full mb-4 items-center gap-2 md:hidden'>
         <div className="flex gap-1">
           <a

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -141,16 +141,16 @@ export default function Home() {
         </h2>
 
         <div className="flex flex-col gap-2">
-          <h3 className="font-semibold">How do I generate a Discord timestamp?</h3>
+          <h3 id="faq-how" className="font-semibold">How do I generate a Discord timestamp?</h3>
           <p className="contentSecondary">
-            Pick a date and time on timestamps.app, then copy any of the six Discord timestamp formats (e.g. <code>&lt;t:1700000000:F&gt;</code>) and paste it into a Discord message. Discord will render it in each viewer&apos;s local timezone.
+            Pick a date and time on timestamps.app, then copy any of the six Discord timestamp formats (e.g. <code>&lt;t:1700000000:F&gt;</code>) and paste it into a Discord message. Discord will render it in each viewer&apos;s local timezone. See the <a href="#faq-format-codes" className="underline">full list of Discord timestamp format codes</a> for what each one renders.
           </p>
         </div>
 
         <div className="flex flex-col gap-2">
-          <h3 className="font-semibold">What do the Discord timestamp format codes mean?</h3>
+          <h3 id="faq-format-codes" className="font-semibold">What do the Discord timestamp format codes mean?</h3>
           <p className="contentSecondary">
-            Discord supports six timestamp format codes. Append the code to a UNIX timestamp inside <code>&lt;t:...&gt;</code> to control how Discord renders the date and time in each viewer&apos;s local timezone.
+            Discord supports six timestamp format codes. Append the code to a UNIX timestamp inside <code>&lt;t:...&gt;</code> to control how Discord renders the date and time in each viewer&apos;s local timezone. For a quick start, see <a href="#faq-how" className="underline">how to generate a Discord timestamp</a>.
           </p>
           <ul className="flex flex-col gap-2 contentSecondary">
             <li><strong><code>:f</code></strong> — Short date and time (e.g. December 25, 2025 3:00 PM)</li>
@@ -163,14 +163,14 @@ export default function Home() {
         </div>
 
         <div className="flex flex-col gap-2">
-          <h3 className="font-semibold">What is a UNIX timestamp?</h3>
+          <h3 id="faq-unix" className="font-semibold">What is a UNIX timestamp?</h3>
           <p className="contentSecondary">
-            A UNIX timestamp is the number of seconds since 00:00:00 UTC on 1 January 1970. It is the format Discord and many other platforms use to represent a moment in time independently of timezone.
+            A UNIX timestamp is the number of seconds since 00:00:00 UTC on 1 January 1970. It is the format Discord and many other platforms use to represent a moment in time independently of timezone. Discord wraps the timestamp in <a href="#faq-format-codes" className="underline">a format code tag</a> to control how it&apos;s displayed.
           </p>
         </div>
 
         <div className="flex flex-col gap-2">
-          <h3 className="font-semibold">Is timestamps.app free?</h3>
+          <h3 id="faq-free" className="font-semibold">Is timestamps.app free?</h3>
           <p className="contentSecondary">
             Yes. timestamps.app is free, requires no sign-up, and runs entirely in your browser.
           </p>

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,22 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: "/api/",
+      },
+      { userAgent: "GPTBot", allow: "/" },
+      { userAgent: "ChatGPT-User", allow: "/" },
+      { userAgent: "OAI-SearchBot", allow: "/" },
+      { userAgent: "ClaudeBot", allow: "/" },
+      { userAgent: "Claude-Web", allow: "/" },
+      { userAgent: "PerplexityBot", allow: "/" },
+      { userAgent: "Google-Extended", allow: "/" },
+      { userAgent: "CCBot", allow: "/" },
+    ],
+    sitemap: "https://timestamps.app/sitemap.xml",
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,12 +1,25 @@
 import type { MetadataRoute } from "next";
 
 export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
   return [
     {
       url: "https://timestamps.app",
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: "weekly",
       priority: 1,
+    },
+    {
+      url: "https://timestamps.app/formats",
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: "https://timestamps.app/unix-timestamp",
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.8,
     },
   ];
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: "https://timestamps.app",
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+  ];
+}

--- a/app/unix-timestamp/page.tsx
+++ b/app/unix-timestamp/page.tsx
@@ -1,0 +1,181 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "What is a UNIX Timestamp? — Epoch Time Explained",
+  description:
+    "A UNIX timestamp is the number of seconds since 1 January 1970 UTC. Learn how it works, why it's used everywhere from Discord to databases, and how to convert one.",
+  alternates: { canonical: "/unix-timestamp" },
+  openGraph: {
+    title: "What is a UNIX Timestamp? — Epoch Time Explained",
+    description:
+      "A UNIX timestamp is the number of seconds since 1 January 1970 UTC. Learn how it works and how to convert one.",
+    url: "https://timestamps.app/unix-timestamp",
+    siteName: "timestamps.app",
+    type: "article",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "What is a UNIX Timestamp?",
+    description:
+      "The number of seconds since 1 January 1970 UTC — explained with examples.",
+  },
+};
+
+const articleSchema = {
+  "@context": "https://schema.org",
+  "@type": "Article",
+  headline: "What is a UNIX Timestamp?",
+  description:
+    "A plain-language explanation of UNIX timestamps: what they are, how they work, and why they're used in Discord, databases, and APIs.",
+  url: "https://timestamps.app/unix-timestamp",
+  author: {
+    "@type": "Person",
+    name: "Niklas Peterson",
+    url: "https://niklaspeterson.com",
+  },
+  publisher: {
+    "@type": "Organization",
+    name: "timestamps.app",
+    url: "https://timestamps.app",
+  },
+  datePublished: "2026-05-05",
+  dateModified: new Date().toISOString().slice(0, 10),
+  mainEntityOfPage: {
+    "@type": "WebPage",
+    "@id": "https://timestamps.app/unix-timestamp",
+  },
+};
+
+export default function UnixTimestampPage() {
+  return (
+    <main className="w-full max-w-3xl px-4 py-12 md:py-20 flex flex-col gap-10">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+
+      <Link
+        href="/"
+        className="text-sm contentSecondary hover:contentPrimary w-fit focusLinkInline"
+      >
+        ← timestamps.app
+      </Link>
+
+      <article className="flex flex-col gap-10">
+        <header className="flex flex-col gap-4">
+          <h1 className="text-4xl md:text-5xl font-semibold">
+            What is a UNIX timestamp?
+          </h1>
+          <p className="text-lg contentSecondary">
+            A UNIX timestamp is the number of seconds that have elapsed since 00:00:00 UTC on
+            1 January 1970 — a moment known as the <em>UNIX epoch</em>. It&apos;s the format
+            most software uses internally to represent a single instant in time, independent
+            of timezone.
+          </p>
+        </header>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-2xl md:text-3xl font-semibold">Why count seconds since 1970?</h2>
+          <p className="contentSecondary">
+            UNIX, the operating system that most of today&apos;s servers descend from, was
+            designed in the early 1970s. Its engineers picked 1 January 1970 UTC as a fixed
+            reference point and stored every date as the count of seconds since then. The
+            convention stuck. Almost every programming language, database, and API uses some
+            variant of it: JavaScript counts milliseconds since 1970, most other systems count
+            seconds.
+          </p>
+          <p className="contentSecondary">
+            The point of using a single integer is that it has no timezone, no daylight saving
+            ambiguity, and no calendar quirks. <code>1735138800</code> means the same instant
+            in New York as it does in Tokyo — only how we display it changes.
+          </p>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-2xl md:text-3xl font-semibold">A few examples</h2>
+          <ul className="flex flex-col gap-2 contentSecondary">
+            <li>
+              <code>0</code> — 1 January 1970, 00:00:00 UTC (the epoch itself)
+            </li>
+            <li>
+              <code>1000000000</code> — 9 September 2001, 01:46:40 UTC
+            </li>
+            <li>
+              <code>1700000000</code> — 14 November 2023, 22:13:20 UTC
+            </li>
+            <li>
+              <code>1735138800</code> — 25 December 2025, 15:00:00 (3 PM) in New York
+            </li>
+          </ul>
+          <p className="contentSecondary">
+            You can paste any of these into the{" "}
+            <Link href="/" className="underline">timestamp generator</Link> to see them
+            rendered in your local timezone.
+          </p>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-2xl md:text-3xl font-semibold">Where UNIX timestamps show up</h2>
+          <p className="contentSecondary">
+            Anywhere software needs to record &quot;when&quot;: file modification times, log
+            entries, database rows, JWT expirations, API responses, OAuth tokens, and Discord
+            messages. Discord in particular uses UNIX timestamps inside its{" "}
+            <Link href="/formats" className="underline">timestamp format tags</Link> so that a
+            single message renders correctly for users in every timezone.
+          </p>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-2xl md:text-3xl font-semibold">Seconds vs milliseconds</h2>
+          <p className="contentSecondary">
+            Two conventions exist side by side. Most languages and databases store UNIX time
+            in <strong>seconds</strong> (a 10-digit number for current dates).
+            JavaScript&apos;s <code>Date.now()</code> and many web APIs use{" "}
+            <strong>milliseconds</strong> (a 13-digit number). If a value looks suspiciously
+            large or small by 1000×, that&apos;s usually the reason — divide or multiply by
+            1000 to convert.
+          </p>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-2xl md:text-3xl font-semibold">The year 2038 problem</h2>
+          <p className="contentSecondary">
+            Older systems store UNIX timestamps in a signed 32-bit integer, which overflows on
+            19 January 2038. Modern systems use 64-bit integers, which won&apos;t overflow for
+            roughly 292 billion years — so for everyday use, including Discord, this
+            isn&apos;t something you need to worry about.
+          </p>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-2xl md:text-3xl font-semibold">How to convert a UNIX timestamp</h2>
+          <p className="contentSecondary">
+            The simplest way is to pick a date and time on the{" "}
+            <Link href="/" className="underline">timestamp generator</Link>: it shows you the
+            UNIX timestamp alongside Discord&apos;s six rendered formats, ready to copy. If
+            you&apos;re building software, every major language has a built-in:{" "}
+            <code>Math.floor(Date.now() / 1000)</code> in JavaScript,{" "}
+            <code>time.time()</code> in Python, <code>time()</code> in PHP.
+          </p>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-2xl md:text-3xl font-semibold">Related</h2>
+          <ul className="flex flex-col gap-2">
+            <li>
+              <Link href="/" className="underline">
+                → Generate a Discord or UNIX timestamp
+              </Link>
+            </li>
+            <li>
+              <Link href="/formats" className="underline">
+                → Discord timestamp format reference
+              </Link>
+            </li>
+          </ul>
+        </section>
+      </article>
+    </main>
+  );
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,29 @@
+# timestamps.app
+
+> Free online tool to generate Discord timestamps and UNIX timestamps. Pick any date and time, then copy the <t:...> format Discord and other platforms need. No sign-up required.
+
+## About
+
+timestamps.app helps users create Discord-ready timestamp tags. Discord renders these tags in each viewer's local timezone. The tool is free, requires no sign-up, and runs entirely in the browser. Created and maintained by Niklas Peterson (https://niklaspeterson.com).
+
+## Discord timestamp format codes
+
+Append a code to a UNIX timestamp inside `<t:...>` to control how Discord renders the date and time:
+
+- `:f` — Short date and time (e.g. December 25, 2025 3:00 PM)
+- `:F` — Long date and time (e.g. Thursday, December 25, 2025 3:00 PM)
+- `:d` — Short date (e.g. 12/25/2025)
+- `:D` — Long date (e.g. December 25, 2025)
+- `:t` — Short time (e.g. 3:00 PM)
+- `:R` — Relative time (e.g. "in 3 hours")
+
+A UNIX timestamp is the number of seconds since 00:00:00 UTC on 1 January 1970.
+
+## Pages
+
+- [Home](https://timestamps.app): Generate Discord and UNIX timestamps from any date and time
+- [GitHub repository](https://github.com/NiklasPeterson/timestamps): Source code
+
+## Discord bot
+
+A companion Discord bot is available: https://discord.com/oauth2/authorize?client_id=1031598414280015915

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -22,6 +22,8 @@ A UNIX timestamp is the number of seconds since 00:00:00 UTC on 1 January 1970.
 ## Pages
 
 - [Home](https://timestamps.app): Generate Discord and UNIX timestamps from any date and time
+- [Discord timestamp format reference](https://timestamps.app/formats): Detailed reference for all six Discord timestamp format codes with examples and guidance
+- [What is a UNIX timestamp?](https://timestamps.app/unix-timestamp): Plain-language explainer of UNIX/epoch time, including conversions and Discord usage
 - [GitHub repository](https://github.com/NiklasPeterson/timestamps): Source code
 
 ## Discord bot


### PR DESCRIPTION
## Summary

Improves how AI search engines (ChatGPT, Perplexity, Google AI Overviews) interpret timestamps.app so it gets retrieved and cited as a source for Discord/UNIX timestamp queries. Based on the [AEO guide](https://framer.com/guides/aeo) 8-point checklist.

- **Sharper metadata** in `app/layout.tsx` — Discord-specific title, more descriptive meta description, OpenGraph + Twitter cards, canonical URL, `metadataBase`.
- **Server-rendered JSON-LD** — two `<script type="application/ld+json">` blocks: `WebApplication` (the tool) and `FAQPage` (4 Q&As). Verified to land in the prerendered HTML via `next build`.
- **Visible Discord timestamp format reference section** — explicit list mapping `:f / :F / :d / :D / :t / :R` to their meanings with examples, so AI engines can tie format codes to definitions without inferring.
- **Visible FAQ section** — wording matches the `FAQPage` schema verbatim (mismatches reduce schema trust).

No design or behaviour changes to the existing tool UI; new content stacks below the date picker.

## Test plan

- [x] `npm run build` succeeds
- [x] TypeScript check (`npx tsc --noEmit`) passes
- [x] Both JSON-LD scripts present in `.next/server/app/index.html`
- [x] Updated `<meta name="description">` shipped in SSR HTML
- [x] FAQ visible text matches `FAQPage.acceptedAnswer.text` verbatim
- [ ] After deploy: validate via [Google Rich Results Test](https://search.google.com/test/rich-results)
- [ ] After deploy: confirm OpenGraph preview renders correctly when sharing the URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)